### PR TITLE
Disable most linters, enable them gradually later

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,97 +10,97 @@ run:
 linters:
   disable-all: true
   enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - containedctx
-    - contextcheck
-    - cyclop
-    - decorder
-    - depguard
-    - dogsled
-    - dupl
-    - dupword
-    - durationcheck
-    - errcheck
-    - errchkjson
-    - errname
-    - errorlint
-    - execinquery
-    - exhaustive
-    - exhaustruct
-    - exportloopref
-    - forbidigo
-    - forcetypeassert
-#    - funlen  # Example: Function 'TestGetValidatorBalance' is too long (206 > 60)
-    - gci
-#    - gochecknoglobals  # globals are fine for now
-#    - gochecknoinits  # disable for now
-    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-#    - godot  # Example: Comment should end in a period
-    - godox
-    - goerr113
+#    - asasalint
+#    - asciicheck
+#    - bidichk
+#    - bodyclose
+#    - containedctx
+#    - contextcheck
+#    - cyclop
+#    - decorder
+#    - depguard
+#    - dogsled
+#    - dupl
+#    - dupword
+#    - durationcheck
+#    - errcheck
+#    - errchkjson
+#    - errname
+#    - errorlint
+#    - execinquery
+#    - exhaustive
+#    - exhaustruct
+#    - exportloopref
+#    - forbidigo
+#    - forcetypeassert
+##    - funlen  # Example: Function 'TestGetValidatorBalance' is too long (206 > 60)
+#    - gci
+##    - gochecknoglobals  # globals are fine for now
+##    - gochecknoinits  # disable for now
+#    - gocognit
+#    - goconst
+#    - gocritic
+#    - gocyclo
+##    - godot  # Example: Comment should end in a period
+#    - godox
+#    - goerr113
     - gofmt
-    - gofumpt
-    - goheader
-    - goimports
-    - gomnd
-    - gomoddirectives
-    - gomodguard
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - grouper
-    - importas
-    - ineffassign
-    - interfacebloat
-    - ireturn
-#    - lll  # disable line length for now
-    - loggercheck
-    - maintidx
-    - makezero
-    - misspell
-    - nakedret
-    - nestif
-    - nilerr
-    - nilnil
-    - nlreturn
-    - noctx
-    - nolintlint
-    - nonamedreturns
-    - nosprintfhostport
-    - paralleltest
-    - prealloc
-    - predeclared
-    - promlinter
-    - reassign
-    - revive
-#    - rowserrcheck is disabled because of generics
-#    - sqlclosecheck is disabled because of generics
-    - staticcheck
-#    - structcheck is disabled because of generics
-    - stylecheck
-    - tagliatelle
-    - tenv
-    - testableexamples
-    - testpackage
-    - thelper
-    - tparallel
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - usestdlibvars
-#    - varnamelen  # example: parameter name 'rw' is too short for the scope of its usage
-#    - wastedassign is disabled because of generics
-    - whitespace
-    - wrapcheck
-    - wsl
+#    - gofumpt
+#    - goheader
+#    - goimports
+#    - gomnd
+#    - gomoddirectives
+#    - gomodguard
+#    - goprintffuncname
+#    - gosec
+#    - gosimple
+#    - govet
+#    - grouper
+#    - importas
+#    - ineffassign
+#    - interfacebloat
+#    - ireturn
+##    - lll  # disable line length for now
+#    - loggercheck
+#    - maintidx
+#    - makezero
+#    - misspell
+#    - nakedret
+#    - nestif
+#    - nilerr
+#    - nilnil
+#    - nlreturn
+#    - noctx
+#    - nolintlint
+#    - nonamedreturns
+#    - nosprintfhostport
+#    - paralleltest
+#    - prealloc
+#    - predeclared
+#    - promlinter
+#    - reassign
+#    - revive
+##    - rowserrcheck is disabled because of generics
+##    - sqlclosecheck is disabled because of generics
+#    - staticcheck
+##    - structcheck is disabled because of generics
+#    - stylecheck
+#    - tagliatelle
+#    - tenv
+#    - testableexamples
+#    - testpackage
+#    - thelper
+#    - tparallel
+#    - typecheck
+#    - unconvert
+#    - unparam
+#    - unused
+#    - usestdlibvars
+##    - varnamelen  # example: parameter name 'rw' is too short for the scope of its usage
+##    - wastedassign is disabled because of generics
+#    - whitespace
+#    - wrapcheck
+#    - wsl
 
 linters-settings:
   gofmt:


### PR DESCRIPTION
After golangci enabled a lot of errors appeared. Disable for now to have more time to do fixes.

## Changes:
- disable most linters
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests?**

- [ ] Yes
- [ ] No
